### PR TITLE
update: Add OpenSearch in Search engine section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The "plungers" we use in our job day-to-day.
 - [Apache Solr](http://lucene.apache.org/solr/)
 - [Elasticsearch](https://www.elastic.co/downloads/elasticsearch)
 - [Vespa](http://vespa.ai)
+- [OpenSearch](https://opensearch.org/)
 
 ## Learning to Rank Tooling
 


### PR DESCRIPTION
## What
SSIA

## Why
OpenSearch is also mainstream for search engine at now.